### PR TITLE
[release-2.9] Set cgo flag on PROMU to build dynamically linked binary

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -192,6 +192,7 @@ common-unused:
 	$(GO) mod tidy
 	@git diff --exit-code -- go.sum go.mod
 
+# NOTICE: must --cgo flag to build dynamically linked binary for FIPS compliance
 .PHONY: common-build
 common-build: promu
 ifneq ($(shell which promu), $(PROMU))
@@ -200,7 +201,7 @@ ifneq ($(shell which promu), $(PROMU))
 endif
 
 	@echo ">> building binaries"
-	$(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
+	$(PROMU) build --cgo --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu


### PR DESCRIPTION
Adding `--cgo` flag to ensure builds are dynamically linked.