### PR TITLE
[release-2.6] Set cgo flag on PROMU to build dynamically linked binary

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -225,10 +225,11 @@ endif
 endif
 endif
 
+# NOTICE: must --cgo flag to build dynamically linked binary for FIPS compliance
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --cgo --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu


### PR DESCRIPTION
Adding `--cgo` flag to ensure builds are dynamically linked.