### PR TITLE
Backport alert-manager CI changes to release-2.17 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - run: git diff --exit-code
 
   build:
-    name: Build Alertmanager for common architectures
+    name: Build Alertmanager builds for common architectures
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,12 @@ linters:
       - linters:
           - modernize
         text: "omitzero: Omitempty has no effect on nested struct fields"
+      - linters:
+          - modernize
+        text: "waitgroupgo:"
+      - linters:
+          - staticcheck
+        text: "QF1012:"
     warn-unused: true
 issues:
   max-issues-per-linter: 0

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -575,7 +575,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 				cfg.Hello = "invalid hello string"
 			},
 
-			errMsg: "501 Error",
+			errMsg: "501 \"Error",
 			retry:  true,
 		},
 	} {
@@ -733,7 +733,7 @@ func TestEmailRejected(t *testing.T) {
 
 	// Send the alert to mock SMTP server.
 	retry, err := e.Notify(context.Background(), firingAlert)
-	require.ErrorContains(t, err, "501 5.5.4 Rejected!")
+	require.ErrorContains(t, err, "501 \"5.5.4 Rejected!")
 	require.True(t, retry)
 	require.NoError(t, srv.Shutdown(ctx))
 


### PR DESCRIPTION
This is a backport of https://github.com/stolostron/prometheus-alertmanager/pull/231 to add CI support to release-2.17 