### PR TITLE
Backport alert-manager CI changes to release-2.13

### DIFF
--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -546,7 +546,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 				cfg.Hello = "invalid hello string"
 			},
 
-			errMsg: "501 Error",
+			errMsg: "501 \"Error",
 			retry:  true,
 		},
 	} {


### PR DESCRIPTION
This is a backport of https://github.com/stolostron/prometheus-alertmanager/pull/231 to add CI support to release-2.13.